### PR TITLE
Add Reassure CI script and update workflow

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,0 +1,21 @@
+name: Reassure Performance Check
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  reassure:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - name: Run performance tests
+        run: ./reassure-tests.sh
+      - name: Run Danger.js
+        run: npx danger ci
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore Reassure performance output
+app/.reassure/

--- a/Dangerfile.js
+++ b/Dangerfile.js
@@ -1,0 +1,7 @@
+// Dangerfile generated for Reassure
+const path = require('path');
+const { dangerReassure } = require('reassure');
+
+dangerReassure({
+  inputFilePath: path.join(__dirname, 'app/.reassure/output.md'),
+});

--- a/README.md
+++ b/README.md
@@ -14,3 +14,18 @@ Looking forward to connecting with you!
 ---
 
 ![Profile Views](https://komarev.com/ghpvc/?username=naxirudin&color=blue)
+
+## React Native Performance App
+
+The `app` directory contains a minimal React Native project written in TypeScript. It integrates the [Reassure](https://github.com/callstack/reassure) library for performance regression testing.
+
+Reassure is executed in CI using the `reassure-tests.sh` script which measures the
+baseline branch and the current changes. Danger then posts the comparison
+results back to the pull request.
+
+To try the performance test locally run:
+
+```bash
+./reassure-tests.sh
+```
+The script stores results inside `app/.reassure/` which are used by Danger in CI.

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { SafeAreaView, Text } from 'react-native';
+
+const App = () => {
+  return (
+    <SafeAreaView>
+      <Text>Welcome to React Native with Reassure!</Text>
+    </SafeAreaView>
+  );
+};
+
+export default App;

--- a/app/README.md
+++ b/app/README.md
@@ -1,0 +1,14 @@
+# RN Performance App
+
+This project demonstrates a simple React Native application configured with the [Reassure](https://github.com/callstack/reassure) performance regression tool and Danger integration.
+
+## Available scripts
+
+- `npm run start` - start metro server
+- `npm run android` / `npm run ios` - run the app on a device or emulator
+- `npm run reassure` - run Reassure locally
+- `../reassure-tests.sh` - run the full baseline comparison used in CI
+
+## GitHub Actions
+
+The workflow `.github/workflows/performance.yml` executes `reassure-tests.sh` and then runs Danger to comment on pull requests.

--- a/app/babel.config.js
+++ b/app/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ['module:metro-react-native-babel-preset'],
+};

--- a/app/index.js
+++ b/app/index.js
@@ -1,0 +1,4 @@
+import { AppRegistry } from 'react-native';
+import App from './App';
+
+AppRegistry.registerComponent('RNPerfApp', () => App);

--- a/app/package.json
+++ b/app/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "rn-perf-app",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "react-native start",
+    "android": "react-native run-android",
+    "ios": "react-native run-ios",
+    "test": "jest",
+    "reassure": "reassure --config reassure.config.js"
+  },
+  "dependencies": {
+    "react": "18.2.0",
+    "react-native": "0.72.0"
+  },
+  "devDependencies": {
+    "typescript": "5.0.4",
+    "@types/react": "18.0.28",
+    "@types/react-native": "0.72.0",
+    "reassure": "^1.0.0",
+    "danger": "^11.0.0",
+    "jest": "29.0.0",
+    "react-test-renderer": "18.2.0"
+  }
+}

--- a/app/reassure.config.js
+++ b/app/reassure.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  scenarios: [
+    {
+      name: 'App Start',
+      script: 'index.js',
+    },
+  ],
+};

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "jsx": "react",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "exclude": ["node_modules", "babel.config.js"]
+}

--- a/reassure-tests.sh
+++ b/reassure-tests.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -e
+
+# Baseline branch defaults to main
+BASELINE_BRANCH=${GITHUB_BASE_REF:-"main"}
+
+# Ensure we have all branches
+git fetch origin
+
+# Measure baseline performance
+git switch "$BASELINE_BRANCH"
+cd app
+npm install
+npx reassure --config reassure.config.js --baseline
+cd ..
+
+# Measure current performance
+git switch --detach -
+cd app
+npm install
+npx reassure --config reassure.config.js
+cd ..


### PR DESCRIPTION
## Summary
- add `reassure-tests.sh` script for baseline comparison
- integrate Danger via `dangerReassure` plugin
- update GitHub Actions workflow to run the script and Danger
- document usage in README files
- ignore Reassure output

## Testing
- `npm install` *(fails: 403 Forbidden to registry.npmjs.org)*
- `npm test` *(fails: jest not found)*
- `./reassure-tests.sh` *(fails: origin not a git repo)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_685a8f0245a083328144ee26bf901411